### PR TITLE
fix @import and @font-face in css parser

### DIFF
--- a/test/test_css_parser_loading.rb
+++ b/test/test_css_parser_loading.rb
@@ -132,6 +132,52 @@ class CssParserLoadingTests < Minitest::Test
     end
   end
 
+  def test_allowing_at_import_rules_from_add_block
+    css_block = "@import 'https://fonts.googleapis.com/css?family=Suez+One';"
+
+    parser = Parser.new
+    parser.add_block!(css_block, :ignore_import => false)
+
+    assert_equal true, css_block.include?("@import")
+  end
+
+  def test_ignoring_at_import_rules_from_add_block
+    css_block = "@import 'https://fonts.googleapis.com/css?family=Suez+One';"
+
+    parser = Parser.new
+    parser.add_block!(css_block, :ignore_import => true)
+
+    assert_equal false, css_block.include?("@import")
+  end
+
+  # in order for font-face to work we need to make sure new lines are
+  # removed after passing css_block to add_block!
+  def test_allowing_font_face_rule
+
+    css_block = "@font-face {
+      src: url('https://test.css.net/1') format('f1'),
+      url('https://test.css.net/2') format('f2');
+      }"
+
+    parser = Parser.new
+    parser.add_block!(css_block, :allow_font_face => true)
+
+    assert_equal false, css_block.include?("\n")
+  end
+
+  def test_not_allowing_font_face_rule
+
+    css_block = "@font-face {
+      src: url('https://test.css.net/1') format('f1'),
+      url('https://test.css.net/2') format('f2');
+      }"
+
+    parser = Parser.new
+    parser.add_block!(css_block, :allow_font_face => false)
+
+    assert_equal true, css_block.include?("\n")
+  end
+
   def test_following_badly_escaped_import_rules
     css_block = '@import "http://example.com/css?family=Droid+Sans:regular,bold|Droid+Serif:regular,italic,bold,bolditalic&subset=latin";'
 


### PR DESCRIPTION
This fixes 2 issues:
1.css_parser gem removes @import rules when parsing, this branch will give you and option to ignore that.
2.css_parser gem does not know how to parse @font-face correctly unless the whole rule is in one line.
https://redmine.wishpond.com/issues/104223722
https://redmine.wishpond.com/issues/104223582

Initial checklist:
- [x] Tested code locally
- [x] Commit message is good

After CR checklist:
- [ ] All Code Review comments taken care of
