### PR TITLE
add the ability to parse @import into rules sets

### DIFF
--- a/lib/css_parser/rule_set.rb
+++ b/lib/css_parser/rule_set.rb
@@ -109,7 +109,17 @@ module CssParser
      str = ''
      each_declaration do |prop, val, is_important|
        importance = (options[:force_important] || is_important) ? ' !important' : ''
-       str += "#{prop}: #{val}#{importance}; "
+       # we need to trick css parser gem into thinking @import is a css selector and
+       # whatever comes after up to ; is the declaration. however declaration consists
+       # of two parts: property and value. so we need to go from
+       # from  "#{prop}: #{val}#{importance}; "
+       #    to "#{prop}:#{val}#{importance}; "
+       # this will result import rules to work properly and import urls not to break.
+       if selectors.include?("@import")
+         str += "#{prop}:#{val}#{importance}; "
+       else
+         str += "#{prop}: #{val}#{importance}; "
+       end
      end
      str.gsub(/^[\s^(\{)]+|[\n\r\f\t]*|[\s]+$/mx, '').strip
     end

--- a/lib/css_parser/version.rb
+++ b/lib/css_parser/version.rb
@@ -1,3 +1,3 @@
 module CssParser
-  VERSION = "1.4.5".freeze
+  VERSION = "1.4.6".freeze
 end

--- a/test/test_css_parser_basic.rb
+++ b/test/test_css_parser_basic.rb
@@ -43,6 +43,12 @@ class CssParserBasicTests < Minitest::Test
     assert_equal 'color: blue;', @cp.find_by_selector('div').join(' ')
   end
 
+  def test_adding_an_import_ruleset
+    rs = CssParser::RuleSet.new('@import', 'https://fonts.googleapis.com/css?family=Advent+Pro:500,700;')
+    @cp.add_rule_set!(rs)
+    assert_equal ['https://fonts.googleapis.com/css?family=Advent+Pro:500,700;'], @cp.find_by_selector('@import')
+  end
+
   def test_toggling_uri_conversion
     # with conversion
     cp_with_conversion = Parser.new(:absolute_paths => true)

--- a/test/test_css_parser_loading.rb
+++ b/test/test_css_parser_loading.rb
@@ -133,7 +133,7 @@ class CssParserLoadingTests < Minitest::Test
   end
 
   def test_allowing_at_import_rules_from_add_block
-    css_block = "@import 'https://fonts.googleapis.com/css?family=Suez+One';"
+    css_block = "@import 'https://font.test.com/css?family=font+test';"
 
     parser = Parser.new
     parser.add_block!(css_block, :ignore_import => false)
@@ -142,7 +142,7 @@ class CssParserLoadingTests < Minitest::Test
   end
 
   def test_ignoring_at_import_rules_from_add_block
-    css_block = "@import 'https://fonts.googleapis.com/css?family=Suez+One';"
+    css_block = "@import 'https://font.test.com/css?family=font+test';"
 
     parser = Parser.new
     parser.add_block!(css_block, :ignore_import => true)
@@ -150,8 +150,19 @@ class CssParserLoadingTests < Minitest::Test
     assert_equal false, css_block.include?("@import")
   end
 
-  # in order for font-face to work we need to make sure new lines are
-  # removed after passing css_block to add_block!
+  ############ This Comment is for the next two tests: ##############
+  # test_allowing_font_face_rule and test_not_allowing_font_face_rule
+  #
+  # If font-face is allowed and the css block contains font-face
+  # then put all block in one line and remove new lines,
+  # the css parser cant handle @font-face otherwise.
+  #
+  #     # this check is inside add_block! method.
+  #     if options[:allow_font_face] && !(block !~ RE_AT_FONTFACE_RULE)
+  #      block.gsub!(/\n/, "")
+  #     end
+  # !(block !~ RE_AT_FONTFACE_RULE) will return true if font-face exists.
+
   def test_allowing_font_face_rule
 
     css_block = "@font-face {


### PR DESCRIPTION
https://redmine.wishpond.com/issues/104223863

having @import rules with font weight 500 and 700 like 

```
@import 'https://fonts.googleapis.com/css?family=Advent+Pro:500,700';
```

breaks because of the " , " 
This branch allows parse_block_into_rule_sets method to correctly parse @imports into css rule sets. 

Related to: https://github.com/wishpond-dev/wishpondv1/pull/3908

Initial checklist:
- [x] Tested code locally
- [x] Commit message is good

After CR checklist:
- [ ] All Code Review comments taken care of
